### PR TITLE
Fix README clone step path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ store and manage all relevant data, including user information, course details, 
 1. **Clone the Repository**
    ```sh
    git clone https://github.com/jchanthy/KnowledgeCube.git
-   cd knowledge_cube 
+   cd KnowledgeCube
    ```
 
 2. **Install Dependencies**


### PR DESCRIPTION
## Summary
- correct the repository directory name in setup instructions

## Testing
- `npm test --silent` within `frontend` *(fails: react-scripts not found)*
- `npm test --silent` within `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e5e9fe24832fa71d7015549977aa