### PR TITLE
Use verifyToken from controller in JWT middleware

### DIFF
--- a/backend/controllers/user.js
+++ b/backend/controllers/user.js
@@ -222,6 +222,7 @@ export const verifyToken = async (token) => {
 
         if (!findUser) return Promise.reject({error: "Unauthorized"});
         await verify(token);
+        return findUser;
     } catch (error) {
         return Promise.reject({error: "Unauthorized"});
     }

--- a/backend/middleware/jwtProtection.js
+++ b/backend/middleware/jwtProtection.js
@@ -1,6 +1,6 @@
-import verify from "../routes/api/verify.js";
+import {verifyToken as validateToken} from "../controllers/user.js";
 
-const verifyToken = (req, res, next) => {
+const verifyToken = async (req, res, next) => {
     const authHeader = req.headers['Authorization'];
 
     if (!authHeader) {
@@ -15,11 +15,11 @@ const verifyToken = (req, res, next) => {
     }
 
     try {
-        req.user = verify(token, process.env.JWT_SECRET);
+        req.user = await validateToken(token);
+        return next();
     } catch (err) {
         return res.status(401).send('Invalid Token');
     }
-    return next();
 };
 
 export default verifyToken;


### PR DESCRIPTION
## Summary
- validate JWTs in middleware using controller's `verifyToken`
- return the user from `verifyToken` in controllers so middleware can store it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e5ca77c8832f9f1bae3d98e13684