### PR TITLE
Fix async password hashing and validation

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -62,19 +62,23 @@ const userSchema = new Schema({
     }],
 })
 
-userSchema.pre("save", function (next) {
+userSchema.pre("save", async function (next) {
     if (!this.isModified("password")) {
         return next();
     }
-    this.password = bcrypt.hash(this.password, 10);
-    next();
+    try {
+        this.password = await bcrypt.hash(this.password, 10);
+        next();
+    } catch (err) {
+        next(err);
+    }
 });
 
 userSchema.method.checkPassword = async function (password) {
     try {
         const match = await bcrypt.compare(password, this.password);
-        if (match) {
-            return Promise.resolve();
+        if (!match) {
+            return Promise.reject(new Error("Invalid password"));
         }
         return Promise.resolve();
     } catch (error) {


### PR DESCRIPTION
## Summary
- hash passwords properly during save hook
- make checkPassword reject on mismatch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e5b85cd8832fab992c675e690c2d